### PR TITLE
Fix doc comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use types::{RsaImportFormat, RsaPublicParts};
 mod crypto_traits;
 pub use crypto_traits::{Rsa2048Pkcs1v15, Rsa3072Pkcs1v15, Rsa4096Pkcs1v15};
 
-/// Trussed [`Backend`](trussed::backend::Backend) implementation adding support for RSA
+/// Trussed [`Backend`][] implementation adding support for RSA
 ///
 /// This implementation is done in software and requieres an allocator
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -3,8 +3,9 @@
 
 #![cfg(feature = "virt")]
 
-///! Test that the core backend is still reachable.
-///! Tests imported from the trussed repo
+//! Test that the core backend is still reachable.
+//! Tests imported from the trussed repo
+
 use trussed::{client::CertificateClient as _, syscall, try_syscall, types::Location::*};
 use trussed_rsa_alloc::virt;
 


### PR DESCRIPTION
This fixes a clippy warning from a new lint introduced in 1.70.0.