### PR TITLE
Update RSA dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ delog = "0.1.6"
 heapless-bytes = "0.3.0"
 num-bigint-dig = { version = "0.8.2", default-features = false }
 postcard = { version = "0.7", default-features = false, features = ["heapless"] }
-rsa = { version = "0.8.1", default-features = false, features = ["sha2"]}
+rsa = { version = "0.9", default-features = false, features = ["sha2"]}
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 
 trussed = "0.1"
@@ -35,7 +35,7 @@ virt = ["std", "trussed/virt"]
 std = []
 
 # Add support for raw RSA keys
-raw = ["rsa/expose-internals"]
+raw = ["rsa/hazmat"]
 
 log-all = []
 log-none = []

--- a/tests/rsa2048.rs
+++ b/tests/rsa2048.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "virt")]
 
 use rsa::sha2::Sha256;
-use rsa::{Pkcs1v15Encrypt, Pkcs1v15Sign, PublicKeyParts};
+use rsa::{traits::PublicKeyParts, Pkcs1v15Encrypt, Pkcs1v15Sign};
 use trussed::client::CryptoClient;
 use trussed::syscall;
 use trussed::types::KeyId;
@@ -17,7 +17,7 @@ use trussed_rsa_alloc::*;
 
 use hex_literal::hex;
 use num_bigint_dig::BigUint;
-use rsa::{PublicKey, RsaPrivateKey};
+use rsa::RsaPrivateKey;
 
 // Tests below can be run on a PC using the "virt" feature
 

--- a/tests/rsa3072.rs
+++ b/tests/rsa3072.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "virt")]
 
 use rsa::sha2::Sha384;
-use rsa::{Pkcs1v15Encrypt, Pkcs1v15Sign, PublicKeyParts};
+use rsa::{traits::PublicKeyParts, Pkcs1v15Encrypt, Pkcs1v15Sign};
 use trussed::client::CryptoClient;
 use trussed::syscall;
 use trussed::types::KeyId;
@@ -17,7 +17,7 @@ use trussed_rsa_alloc::*;
 
 use hex_literal::hex;
 use num_bigint_dig::BigUint;
-use rsa::{PublicKey, RsaPrivateKey};
+use rsa::RsaPrivateKey;
 
 // Tests below can be run on a PC using the "virt" feature
 

--- a/tests/rsa4096.rs
+++ b/tests/rsa4096.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "virt")]
 
 use rsa::sha2::Sha512;
-use rsa::{Pkcs1v15Encrypt, Pkcs1v15Sign, PublicKeyParts};
+use rsa::{traits::PublicKeyParts, Pkcs1v15Encrypt, Pkcs1v15Sign};
 use trussed::client::CryptoClient;
 use trussed::syscall;
 use trussed::types::KeyId;
@@ -17,7 +17,7 @@ use trussed_rsa_alloc::*;
 
 use hex_literal::hex;
 use num_bigint_dig::BigUint;
-use rsa::{PublicKey, RsaPrivateKey};
+use rsa::RsaPrivateKey;
 
 // Tests below can be run on a PC using the "virt" feature
 


### PR DESCRIPTION
This will also prepare us for the coming 0.11 release including the fix for the marvin attack.

This also helps reduce duplicated dependencies in the full NK3 firmware.