### PR TITLE
Fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,6 @@ log-error = []
 
 [patch.crates-io]
 trussed = { git = "https://github.com/Nitrokey/trussed", rev = "6b9a43fbaaf34fe8d69fac0021f8130dd9a436c9" }
-littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-
 
 [profile.dev.package.rsa]
 opt-level = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,10 +192,7 @@ fn serialize_key(
                 Error::InternalError
             })?
         }
-        KeySerialization::Pkcs8Der => pub_key_der.try_into().map_err(|_| {
-            error!("Too large key for serialization");
-            Error::InternalError
-        })?,
+        KeySerialization::Pkcs8Der => pub_key_der.into(),
         _ => {
             return Err(Error::InvalidSerializationFormat);
         }


### PR DESCRIPTION
Remove unused littlefs2 patch and replace try_into with into to fix two compiler and clippy warnings.