### PR TITLE
Add missing log-trace feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ raw = ["rsa/hazmat"]
 
 log-all = []
 log-none = []
+log-trace = []
 log-info = []
 log-debug = []
 log-warn = []


### PR DESCRIPTION
This fixes a new compiler warning for unexpected cfgs.